### PR TITLE
Remaining issues for version 0.3

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<!-- Version Code 0.2.2512-web.3 -->
+<!-- Version Code 0.3.2512-web.7 -->
 <html lang="en" height="100vh">
 
 <head>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "power-reactors",
-  "version": "0.2.2512-web.3",
+  "version": "0.3.2512-web.7",
   "private": true,
   "type": "module",
   "engines": {

--- a/src/components/News.vue
+++ b/src/components/News.vue
@@ -25,7 +25,6 @@ onMounted(async () => {
         }
     }).then((data) => {
         newsItems.value = data.items;
-        console.log("Fetched news items:", newsItems.value);
     }).catch((error) => {
         console.error("Error fetching data:", error);
     });

--- a/src/components/News.vue
+++ b/src/components/News.vue
@@ -25,6 +25,7 @@ onMounted(async () => {
         }
     }).then((data) => {
         newsItems.value = data.items;
+        console.log("Fetched news items:", newsItems.value);
     }).catch((error) => {
         console.error("Error fetching data:", error);
     });
@@ -37,7 +38,8 @@ onMounted(async () => {
             <li v-for="(item, index) in newsItems" :key="index">
                 <div class="item-title">
                     <img src="@/assets/icons/news-icon.svg" width="24" alt="News" />
-                    <a :href="item.link" target="_blank" rel="noopener">{{ item.title }}</a>
+                    <a v-if="item.link" :href="item.link" target="_blank" rel="noopener"><span class="item-link">{{ item.title }}</span><span class="link-symbol">&#x1F517;</span></a>
+                    <span v-else>{{ item.title }}</span>
                 </div>
                 <div class="item-footer">{{ item.pubDate }}</div>
             </li>
@@ -47,7 +49,7 @@ onMounted(async () => {
 <style scoped>
 .news-page {
     display: flex;
-    flex-direction: column;
+    flex-direction: column; 
     align-items: center;
     justify-content: center;
 }
@@ -55,6 +57,19 @@ onMounted(async () => {
     display: flex;
     align-items: flex-start;
     gap: 8px;
+}
+.item-link {
+    text-decoration: underline;
+    color: inherit;
+}
+.link-symbol {
+    margin-left: 4px;
+    font-size: 0.8em;
+}
+@media (prefers-color-scheme: dark) {
+    .item-title img {
+        filter: invert(97%) sepia(2%) saturate(4393%) hue-rotate(181deg) brightness(107%) contrast(91%);
+    }
 }
 .item-footer {
     font-size: 0.8em;

--- a/src/components/Plants.vue
+++ b/src/components/Plants.vue
@@ -80,7 +80,7 @@ function statusColor(p) {
     }
 };
 function showStation(link) {
-    if (link != undefined && link != null && link.length > 0) {
+    if (link && link.length > 0) {
         window.open(link, '_blank');
     }
 }

--- a/src/components/Plants.vue
+++ b/src/components/Plants.vue
@@ -80,7 +80,6 @@ function statusColor(p) {
     }
 };
 function showStation(link) {
-    console.log("Opening link:", link);
     if (link != undefined && link != null && link.length > 0) {
         window.open(link, '_blank');
     }

--- a/src/components/Plants.vue
+++ b/src/components/Plants.vue
@@ -88,7 +88,7 @@ function showStation(link) {
 
 <template>
     <div class="plants-page">
-        <div class="last-updated">{{ lastUpdated }}</div>
+        <div class="last-updated" v-if="lastUpdated">{{ lastUpdated }}</div>
         <ul>
             <li v-for="station in stations" :key="station.Name">
                 <div class="plant-item">

--- a/src/components/Plants.vue
+++ b/src/components/Plants.vue
@@ -15,6 +15,9 @@ const serviceUrl = process.env.NODE_ENV === 'development'
 let stations = ref(plants);
 let lastUpdated = ref(null);
 
+// Plant links: https://www.nrc.gov/info-finder/reactors/ano1.html
+
+
 onMounted(async () => {
     fetch(serviceUrl, {
         headers: {
@@ -47,6 +50,7 @@ function processData(data) {
             let powerMatch = stationData.title.match(/- (\d+)% power/i);
             let power = powerMatch ? powerMatch[1] : null;
             updatedStation.Status = power;
+            updatedStation.link = stationData.link.replace('/reactors/', '/info-finder/reactors/');
         }
         return updatedStation;
     });
@@ -75,6 +79,12 @@ function statusColor(p) {
         return plantsIconYellow;
     }
 };
+function showStation(link) {
+    console.log("Opening link:", link);
+    if (link != undefined && link != null && link.length > 0) {
+        window.open(link, '_blank');
+    }
+}
 </script>
 
 <template>
@@ -83,7 +93,7 @@ function statusColor(p) {
         <ul>
             <li v-for="station in stations" :key="station.Name">
                 <div class="plant-item">
-                    <div class="plant-item-title">
+                    <div class="plant-item-title" @click="showStation(station.link)">
                         <img :src="`${config.nrcApiBaseUrl}${station.Image}`" :alt="station.Name" />
                         <div class="plant-details">
                             <span class="plant-status">
@@ -126,6 +136,7 @@ function statusColor(p) {
 .plant-item-title {
     display: flex;
     flex-direction: row;
+    cursor: pointer;
 }
 
 .plant-item img {


### PR DESCRIPTION
This pull request introduces several user interface improvements and minor feature additions to the `Plants.vue` and `News.vue` components, along with version updates in the project metadata. The main focus is on enhancing usability and accessibility, particularly for plant station and news items, and providing clearer status information.

### UI/UX Improvements

* Added clickable plant station titles in `Plants.vue` that open detailed NRC info pages in a new tab, improving accessibility to external resources.
* Displayed the last updated timestamp for plant data in a fixed position at the top of the page, giving users clearer visibility into data freshness. [[1]](diffhunk://#diff-9f7116c45da365f70be31909a2c77406ea8488629329f2ce66feccc0157ae907L42-R67) [[2]](diffhunk://#diff-9f7116c45da365f70be31909a2c77406ea8488629329f2ce66feccc0157ae907R117-R127)

### News Item Enhancements

* Improved news item rendering in `News.vue` by showing a link icon for items with links and handling items without links gracefully. Also added styling for links and dark mode support for news icons. [[1]](diffhunk://#diff-9e1de1d0914d6d8b88a729ebab62b30b65881b627798ba4107d78e24cb96211dL40-R41) [[2]](diffhunk://#diff-9e1de1d0914d6d8b88a729ebab62b30b65881b627798ba4107d78e24cb96211dR60-R72)

### Version and Metadata Updates

* Updated version codes in `index.html` and `package.json` to `0.3.2512-web.7` to reflect the new release. [[1]](diffhunk://#diff-0eb547304658805aad788d320f10bf1f292797b5e6d745a3bf617584da017051L2-R2) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3)

### Miscellaneous

* Added a comment referencing NRC reactor info links and minor style tweaks for improved readability and interaction cues, such as making plant titles appear clickable. [[1]](diffhunk://#diff-9f7116c45da365f70be31909a2c77406ea8488629329f2ce66feccc0157ae907R16-R19) [[2]](diffhunk://#diff-9f7116c45da365f70be31909a2c77406ea8488629329f2ce66feccc0157ae907R139) [[3]](diffhunk://#diff-9f7116c45da365f70be31909a2c77406ea8488629329f2ce66feccc0157ae907R169) [[4]](diffhunk://#diff-9f7116c45da365f70be31909a2c77406ea8488629329f2ce66feccc0157ae907R185-L156)